### PR TITLE
bump to latest libvirt version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-RESTful==0.3.5
 itsdangerous==0.24
 Jinja2==2.8
 ldap3==1.0.4
-libvirt-python==1.3.1
+libvirt-python==2.5.0
 MarkupSafe==0.23
 pyasn1==0.1.9
 python-dateutil==2.4.2


### PR DESCRIPTION
It is not possible to install the old version via pip on archlinux:
```
$ pip install -r requirements.txt 
Collecting libvirt-python==1.3.1 (from -r requirements.txt (line 1))
  Using cached libvirt-python-1.3.1.tar.gz
Building wheels for collected packages: libvirt-python
  Running setup.py bdist_wheel for libvirt-python ... error
  Complete output from command /tmp/test/prod/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-8oojt5pw/libvirt-python/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpu00u5fa4pip-wheel- --python-tag cp35:
  running bdist_wheel
  running build
  /usr/bin/pkg-config --print-errors --atleast-version=0.9.11 libvirt
  /tmp/test/prod/bin/python3 generator.py libvirt /usr/share/libvirt/api/libvirt-api.xml
  Found 415 functions in /usr/share/libvirt/api/libvirt-api.xml
  Found 0 functions in libvirt-override-api.xml
  Generated 342 wrapper functions
  Missing type converters:
  virConnectStoragePoolEventGenericCallback:1
  virTypedParameterPtr:1
  virConnectNodeDeviceEventGenericCallback:1
  virTypedParameterPtr *:2
  ERROR: failed virConnectNodeDeviceEventRegisterAny
  ERROR: failed virConnectStoragePoolEventRegisterAny
  ERROR: failed virDomainGetGuestVcpus
  ERROR: failed virDomainGetPerfEvents
  ERROR: failed virDomainSetPerfEvents
  error: command '/tmp/test/prod/bin/python3' failed with exit status 1
  
  ----------------------------------------
  Failed building wheel for libvirt-python
  Running setup.py clean for libvirt-python
Failed to build libvirt-python
Installing collected packages: libvirt-python
  Running setup.py install for libvirt-python ... error
    Complete output from command /tmp/test/prod/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-8oojt5pw/libvirt-python/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-yiujeotq-record/install-record.txt --single-version-externally-managed --compile --install-headers /tmp/test/prod/include/site/python3.5/libvirt-python:
    running install
    running build
    /usr/bin/pkg-config --print-errors --atleast-version=0.9.11 libvirt
    /tmp/test/prod/bin/python3 generator.py libvirt /usr/share/libvirt/api/libvirt-api.xml
    Found 415 functions in /usr/share/libvirt/api/libvirt-api.xml
    Found 0 functions in libvirt-override-api.xml
    Generated 342 wrapper functions
    Missing type converters:
    virConnectNodeDeviceEventGenericCallback:1
    virTypedParameterPtr:1
    virTypedParameterPtr *:2
    virConnectStoragePoolEventGenericCallback:1
    ERROR: failed virConnectNodeDeviceEventRegisterAny
    ERROR: failed virConnectStoragePoolEventRegisterAny
    ERROR: failed virDomainGetGuestVcpus
    ERROR: failed virDomainGetPerfEvents
    ERROR: failed virDomainSetPerfEvents
    error: command '/tmp/test/prod/bin/python3' failed with exit status 1
    
    ----------------------------------------
Command "/tmp/test/prod/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-8oojt5pw/libvirt-python/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-yiujeotq-record/install-record.txt --single-version-externally-managed --compile --install-headers /tmp/test/prod/include/site/python3.5/libvirt-python" failed with error code 1 in /tmp/pip-build-8oojt5pw/libvirt-python/
```

After updating the requirements.txt to the latest libvirt version, everything works again:
```
$ pip install -r requirements.txt 
Collecting libvirt-python==2.5.0 (from -r requirements.txt (line 1))
  Downloading libvirt-python-2.5.0.tar.gz (172kB)
    100% |████████████████████████████████| 174kB 3.9MB/s 
Building wheels for collected packages: libvirt-python
  Running setup.py bdist_wheel for libvirt-python ... done
  Stored in directory: /home/bastelfreak/.cache/pip/wheels/c1/03/d1/606d414ceac8abd87cb309594fe710c5cce3a66c106250dc4e
Successfully built libvirt-python
Installing collected packages: libvirt-python
Successfully installed libvirt-python-2.5.0
```