### PR TITLE
use lowercase mac addr for filename

### DIFF
--- a/marmoset/installimage/installimage_config.py
+++ b/marmoset/installimage/installimage_config.py
@@ -52,7 +52,7 @@ class InstallimageConfig(object):
 
     def file_name(self):
         """Return the file name in the Installimage file name style."""
-        return self.mac.replace(":", "_")
+        return self.mac.replace(":", "_").lower()
 
     def file_path(self, name=None):
         """Return the path to the config file of th instance."""


### PR DESCRIPTION
The installimage scripts will use the following snippet to generate the
supposedly matching filename:
```
awk 'BEGIN {FS="="; RS=" ";} { if ($1 ~ /BOOTIF/) {gsub(/^[^-]+-/, "", $2); gsub(/-/, "_", $2); print tolower($2)}}' /proc/cmdline
```

Because we want to keep it lowercase everywhere, this commit forces it
on the marmoset side of things.
