### PR TITLE
fix flask_restful imports

### DIFF
--- a/marmoset/webserver/dhcp.py
+++ b/marmoset/webserver/dhcp.py
@@ -1,9 +1,6 @@
 """File to handle all web interaction with DHCP records."""
 from flask import request
-from flask.ext.restful import Resource
-from flask.ext.restful import abort
-from flask.ext.restful import reqparse
-from flask.ext.restful import url_for
+from flask_restful import Resource, abort, reqparse, url_for
 
 from marmoset import config as config_reader
 from marmoset import dhcp

--- a/marmoset/webserver/imagecatalog.py
+++ b/marmoset/webserver/imagecatalog.py
@@ -1,5 +1,5 @@
 """Class for handling image metadata."""
-from flask.ext.restful import Resource, abort
+from flask_restful import Resource, abort
 from ..imagecatalog.catalog import ImageCatalog
 
 

--- a/marmoset/webserver/installimage.py
+++ b/marmoset/webserver/installimage.py
@@ -1,6 +1,6 @@
 """File to handle all web interaction with installimage configurations."""
 from flask import request, make_response
-from flask.ext.restful import Resource, url_for, abort
+from flask_restful import Resource, url_for, abort
 
 from ..installimage.installimage_config import InstallimageConfig
 from ..installimage.req_argument_parser import ReqArgumentParser

--- a/marmoset/webserver/installstatus.py
+++ b/marmoset/webserver/installstatus.py
@@ -1,5 +1,5 @@
 """handle all web interaction with status updates from our installimage."""
-from flask.ext.restful import reqparse, Resource, abort
+from flask_restful import reqparse, Resource, abort
 from flask import request
 from marmoset.installstatus import InstallStatus
 from marmoset import validation

--- a/marmoset/webserver/pxe.py
+++ b/marmoset/webserver/pxe.py
@@ -1,5 +1,5 @@
 """File to handle all web interaction with PXE records."""
-from flask.ext.restful import reqparse, Resource, url_for, abort
+from flask_restful import reqparse, Resource, url_for, abort
 
 from .. import pxe
 from marmoset import config as config_reader

--- a/marmoset/webserver/vm.py
+++ b/marmoset/webserver/vm.py
@@ -1,5 +1,5 @@
 """File to handle all web interaction with virtual machines."""
-from flask.ext.restful import reqparse, Resource, abort
+from flask_restful import reqparse, Resource, abort
 
 from .. import virt
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(fname):
 
 setup(
     name='marmoset',
-    version='0.7.0',
+    version='0.7.1',
     description='Simple HTTP API for managing stuff on libvirt hosts',
     keywords='dhcp dhcpd ldap libvirt management vms virtual-machines',
     author='https://github.com/virtapi/marmoset/graphs/contributors',


### PR DESCRIPTION
It seems the flask stuff has changed their naming convention.
Instead of `flask.ext.restful` this particular module is now called
`flask_restful` and needs to be referenced as such in the import
statements.