### PR TITLE
Allow `bin.bz2` as image extension

### DIFF
--- a/marmoset/imagecatalog/catalog.py
+++ b/marmoset/imagecatalog/catalog.py
@@ -6,7 +6,7 @@ import os
 
 class ImageCatalog:
     IMAGE_DIR = '/srv/nfs/images/'
-    IMAGE_EXTENSTIONS = ['tar.gz']
+    IMAGE_EXTENSTIONS = ['tar.gz', 'bin.bz2']
 
     def __init__(self):
         """We don't initialize anything here."""


### PR DESCRIPTION
This is used by coreos/rancher images.